### PR TITLE
Bug 1209961 - Update to gaia-icons 0.10.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "gaia-theme": "gaia-components/gaia-theme"
   },
   "dependencies": {
-    "gaia-icons": "gaia-components/gaia-icons#^0.9.0",
+    "gaia-icons": "gaia-components/gaia-icons#^0.10.0",
     "gaia-component": "gaia-components/gaia-component#^0.3.9"
   }
 }


### PR DESCRIPTION
If I'm not mistaken, the changes between these 2 versions have no consequences on this component, but let's keep it up to date, it would mean less work to check the consequences for next upgrade.
